### PR TITLE
Change headTags from being static.

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -1,12 +1,14 @@
 import React from "react";
 import { HeadProvider } from "react-head";
 
-let headTags = [];
+let headTags = []
 
 export const onRenderBody = ({ setHeadComponents }) => {
   setHeadComponents(headTags);
 };
 
 export const wrapRootElement = ({ element }) => {
+  headTags = [];
+
   return <HeadProvider headTags={headTags}>{element}</HeadProvider>;
 };


### PR DESCRIPTION
Before: headTags, used to generate server head tags, is static.
After: headTags is reset for each page.